### PR TITLE
Proxy support and color added to server task

### DIFF
--- a/lib/ember-cli-helper-view.coffee
+++ b/lib/ember-cli-helper-view.coffee
@@ -8,7 +8,9 @@ class EmberCliHelperView extends View
     @div class: 'ember-cli-helper tool-panel panel-bottom native-key-bindings', =>
       @div class: 'ember-cli-btn-group', =>
         @div class: 'block', =>
-          @button outlet: 'server',   click: 'startServer',       class: 'btn btn-sm inline-block-tight',           'Server'
+          @button outlet: 'server',   click: 'startServer',       class: 'btn btn-sm inline-block-tight', =>
+            @span 'Server '
+            @span outlet: 'serverMark', "\u25CF"
           @button outlet: 'test',     click: 'startTesting',      class: 'btn btn-sm inline-block-tight',           'Test'
           @button outlet: 'generate', click: 'showGeneratorList', class: 'btn btn-sm inline-block-tight',           'Generate'
           @button outlet: 'exit',     click: 'stopProcess',       class: 'btn btn-sm inline-block-tight',           'Exit'
@@ -18,6 +20,7 @@ class EmberCliHelperView extends View
         @ul outlet: 'messages', class: 'list-group'
 
   initialize: ->
+    @lastColor = null
     # Register Commands
     atom.workspaceView.command "ember-cli-helper:toggle", => @toggle()
     atom.workspaceView.command "ember-cli-helper:generate-file", => @showGeneratorList()
@@ -86,7 +89,7 @@ class EmberCliHelperView extends View
       @addLine message
 
       command = atom.config.get('ember-cli-helper.pathToEmberExecutable')
-      args    = [task]
+      args    = [task,"--color"]
       options =
         cwd: atom.project.getPaths()[0] + atom.config.get('ember-cli-helper.emberProjectPath')
       stdout = (out)=> @addLine out
@@ -115,6 +118,9 @@ class EmberCliHelperView extends View
     if @lastProcess == 'test'
       @test.removeClass 'active'
     @lastProcess = null
+  updateServerButton: ->
+    @serverMark.attr 'class', @lastColor
+
 
 
   showGeneratorList: ->
@@ -142,12 +148,36 @@ class EmberCliHelperView extends View
 
   # Borrowed from grunt-runner by @nickclaw
   # https://github.com/nickclaw/atom-grunt-runner
-  addLine: (text, type = "plain") ->
+  addLine: (text) ->
     [panel, messages] = [@panel, @messages]
+    text = text.replace /\ /g, '&nbsp;'
+    text = @colorize text
+    text = @stripColorCodes text
     text = text.trim().replace /[\r\n]+/g, '<br />'
-    stuckToBottom = messages.height() - panel.height() - panel.scrollTop() == 0
-    messages.append "<li class='text-#{type}'>#{text}</li>"
+    stuckToBottom = messages.height() - panel.height() - panel.scrollTop() <= 0
+    messages.append "<li class='text'>#{text}</li>"
+    @updateServerButton()
     panel.scrollTop messages.height() if stuckToBottom
+  colorize:(text) ->
+    self = this
+    text = text.replace /\[([0-9]*)m(.+?)(\[.+?)/g,(string, code, intext, outtext) ->
+        color = null
+        switch code
+          when '1' then color = 'strong'
+          when '4' then color = 'underline'
+          when '31' then color = 'red'
+          when '32' then color = 'green'
+          when '33' then color = 'yellow'
+          when '36' then color = 'cyan'
+          when '90' then color = 'gray'
+        if color
+          self.lastColor = color if code != '1' && code != '4'
+          "<span class='#{color}'>#{intext}</span>#{outtext}"
+        else
+          "#{intext}#{outtext}"
 
+    return text
+  stripColorCodes:(text) ->
+    return text.replace /\[[0-9]{1,2}m/g, ''
   clearPanel: ->
     @messages.empty()

--- a/lib/ember-cli-helper-view.coffee
+++ b/lib/ember-cli-helper-view.coffee
@@ -90,6 +90,10 @@ class EmberCliHelperView extends View
 
       command = atom.config.get('ember-cli-helper.pathToEmberExecutable')
       args    = [task,"--color"]
+      proxyArg = atom.config.get('ember-cli-helper.proxyUrl')
+      if task == 'server' && proxyArg != ''
+        args.push("--proxy")
+        args.push(proxyArg)
       options =
         cwd: atom.project.getPaths()[0] + atom.config.get('ember-cli-helper.emberProjectPath')
       stdout = (out)=> @addLine out

--- a/lib/ember-cli-helper.coffee
+++ b/lib/ember-cli-helper.coffee
@@ -28,6 +28,14 @@ module.exports =
       type: 'string'
       default: '/usr/local/bin/ember'
 
+    proxyUrl:
+      title: 'Proxy URL for Ember --proxy option'
+      description: """
+        Specify an URL for the server you wont to proxy all ajax requests
+        """
+      type: 'string'
+      default: ''
+
     emberProjectPath:
       title: 'Ember Project Path'
       description: """

--- a/stylesheets/ember-cli-helper.less
+++ b/stylesheets/ember-cli-helper.less
@@ -5,9 +5,39 @@
 @import "ui-variables";
 
 .ember-cli-helper {
+  .yellow {
+    color: yellow;
+  }
+  .red {
+    color: #E20000;
+  }
+  .green {
+    color: green;
+  }
+  .cyan {
+    color: cyan;
+  }
+  .gray {
+    color: gray;
+  }
+  .strong {
+    font-weight: 700;
+  }
+  .underline {
+    text-decoration: underline;
+  }
   .panel-body {
     height: 95px;
     overflow: scroll;
+    //borrowed from nickclaw/atom-grunt-runner
+    li {
+      padding: 3px 0px;
+      margin: 0px;
+      font-size: 9pt;
+      line-height: 12pt;
+      white-space: normal;
+      font-family: monospace;
+    }
   }
   .btn:focus {
     outline: 0;


### PR DESCRIPTION
I added --proxy argument support in the configuration and also colour to the terminal. As an addition there is a dot on the server button that has a colour of last colourful message, that makes you run with panel minimised nearly all the time. The only problem is with ember --color option that is needed to make this changes work (until chalk library would accept environment variable to force colour in nodejs) is that it produces warning. However I thing it is so much more convenient with colour and colourful dot that the warning is to be tolerated for some time. Thanks for nice tool. Jan